### PR TITLE
fix: update README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Demo Environment for Introduction to AWS Pentesting 
+# Demo Environment for Introduction to AWS Pentesting
+
 This Terraform project sets up a vulnerable AWS environment for **educational and demonstration purposes**. It is designed for a hands-on demo in the "**Introduction to AWS Pentesting**" webinar.
 
 > ⚠️ **Warning:** This environment is intentionally insecure. Do not deploy it in a production account. Use a dedicated test account and delete all resources after the demo.
@@ -6,8 +7,10 @@ This Terraform project sets up a vulnerable AWS environment for **educational an
 ---
 
 ## 📌 Scenario Overview
+
 This CTF simulates a real-world AWS misconfiguration chain. The attacker will:
-1. Discover a public [S3-hosted static website](http://starwars-anakin-trivia-78o2-bvig.s3-website-ap-southeast-1.amazonaws.com/).
+
+1. Discover a public S3-hosted static website.
 2. Access public S3 bucket version history to recover leaked IAM and Jenkins credentials.
 3. Use the credentials of a limited `test_ops` user.
 4. Find and compromise a Jenkins server to gain temporary credentials for `dev_env_role` by querying IMDS via Jenkins Script Console.
@@ -18,6 +21,7 @@ This CTF simulates a real-world AWS misconfiguration chain. The attacker will:
 ---
 
 ## 🔧 Components Deployed
+
 - **S3 Bucket** (public, versioning enabled, stores credentials)
 - **IAM Users & Roles**:
   - `test_ops`: Limited read-only user
@@ -33,17 +37,22 @@ This CTF simulates a real-world AWS misconfiguration chain. The attacker will:
 ---
 
 ## 🚀 Getting Started
+
 ### 1. Prerequisites
+
 - [Terraform](https://developer.hashicorp.com/terraform/downloads)
 - AWS CLI configured with access to a **sandbox** account
 - An S3 bucket to store Terraform state (optional)
 
 ### 2. Clone This Repo
+
 ```bash
-git clone https://github.com/your-username/aws-pentesting-ctf.git
+git clone https://github.com/rsalunga29/aws-pentesting-ctf.git
 cd aws-pentesting-ctf
 ```
+
 ### 3. Initialize and Apply
+
 ```bash
 export AWS_PROFILE=webinar
 
@@ -53,6 +62,7 @@ terraform apply
 ```
 
 ### 4. Properly Jenkins Server for Demo
+
 1. Wait for up to 10 minutes for Jenkins to be properly installed.
 2. Login to AWS and SSH into the EC2 server using EC2 Instance Connect
 3. Run `sudo cat /var/lib/jenkins/secrets/initialAdminPassword` to get the initial admin password
@@ -62,7 +72,9 @@ terraform apply
 ---
 
 ## 🧹 Cleanup
+
 After your demo or testing session, destroy all the created resources:
+
 ```bash
 terraform destroy
 ```


### PR DESCRIPTION
remove unexisting s3 bucket link
updates the git clone command url to owner's repository name
format README according to markdown linting